### PR TITLE
devcontainerでstreamlit hello

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+SHELL ["/bin/bash", "-c"]
+
+RUN pip install streamlit

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+  "name": "Streamlit Development",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  // "image": "mcr.microsoft.com/devcontainers/base:bullseye"
+  "build": {
+    // Path is relataive to the devcontainer.json file.
+    "dockerfile": "Dockerfile"
+  },
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [8501]
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Issue
+
+<!--
+- https://github.com/peno022/easy-english/issues/xxx
+-->
+
+## 概要
+
+## 動作確認方法
+
+<!--
+例:
+1. {branch_name}をローカルに取り込む
+2. 
+-->
+
+## Screenshot
+
+### 変更前
+
+### 変更後


### PR DESCRIPTION
## Issue
- なし
<!--
- https://github.com/peno022/easy-english/issues/xxx
-->

## 概要

- devcontainerをセットアップ
- prテンプレートを作成
- `streamlit hello`コマンドが実行でき、ローカルでstreamlitのデモサイトが動くことを確認

## 動作確認方法
- `streamlit hello`コマンドを実行する
- ブラウザから`http://localhost:8501/`にアクセスし、streamlitのデモサイトが表示されることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

- なし

### 変更後
![スクリーンショット 2023-04-01 18 30 28](https://user-images.githubusercontent.com/40317050/229278087-15c280a0-7440-4ec8-8e68-89aa1a9a3311.png)

